### PR TITLE
iOS: support for Xcode 11.4 and Fritz 5.3+

### DIFF
--- a/Editor/DownloadFramework.cs
+++ b/Editor/DownloadFramework.cs
@@ -36,9 +36,9 @@ public class DownloadFramework
 
             PluginImporter[] importers = PluginImporter.GetImporters(BuildTarget.iOS);
             foreach (var importer in importers)
-	    {
+            {
                 if (importer.assetPath.StartsWith("Assets/Plugins/iOS/Frameworks/Fritz") && importer.assetPath.EndsWith(".framework"))
-		{
+                {
                     importer.SetPlatformData(BuildTarget.iOS, "AddToEmbeddedBinaries", "true");
                 }
             }

--- a/Editor/DownloadFramework.cs
+++ b/Editor/DownloadFramework.cs
@@ -29,7 +29,7 @@ public class DownloadFramework
 
             client.DownloadFile(new Uri(path), tempFile);
 
-            ExecuteBashCommand(String.Format("unzip -o {0} -d {1}", tempFile, tempDir));
+            ExecuteBashCommand(String.Format("unzip -q -o {0} -d {1}", tempFile, tempDir));
             ExecuteBashCommand(String.Format("mkdir -p Assets/Plugins/iOS/Frameworks/"));
             var result = ExecuteBashCommand(
                 String.Format("cp -R {0}/Frameworks/* {1}", tempDir, "Assets/Plugins/iOS/Frameworks/")
@@ -51,7 +51,9 @@ public class DownloadFramework
                 FileName = "/bin/bash",
                 Arguments = "-c \"" + command + "\"",
                 UseShellExecute = false,
-                RedirectStandardOutput = true,
+                RedirectStandardOutput = false,
+                RedirectStandardError = false,
+                RedirectStandardInput = false,
                 CreateNoWindow = true
             }
         };

--- a/Editor/DownloadFramework.cs
+++ b/Editor/DownloadFramework.cs
@@ -29,12 +29,19 @@ public class DownloadFramework
 
             client.DownloadFile(new Uri(path), tempFile);
 
-            ExecuteBashCommand(String.Format("unzip -q -o {0} -d {1}", tempFile, tempDir));
-            ExecuteBashCommand(String.Format("mkdir -p Assets/Plugins/iOS/Frameworks/"));
             var result = ExecuteBashCommand(
                 String.Format("cp -R {0}/swift-framework-{1}/Frameworks/* {2}", tempDir, version, "Assets/Plugins/iOS/Frameworks/")
             );
-            AssetDatabase.Refresh();
+            AssetDatabase.Refresh(ImportAssetOptions.ForceSynchronousImport | ImportAssetOptions.ForceUpdate);
+
+            PluginImporter[] importers = PluginImporter.GetImporters(BuildTarget.iOS);
+            foreach (var importer in importers)
+	    {
+                if (importer.assetPath.StartsWith("Assets/Plugins/iOS/Frameworks/Fritz") && importer.assetPath.EndsWith(".framework"))
+		{
+                    importer.SetPlatformData(BuildTarget.iOS, "AddToEmbeddedBinaries", "true");
+                }
+            }
         }
     }
 
@@ -50,11 +57,10 @@ public class DownloadFramework
             {
                 FileName = "/bin/bash",
                 Arguments = "-c \"" + command + "\"",
-                UseShellExecute = false,
                 RedirectStandardOutput = true,
-                RedirectStandardError = true,
                 RedirectStandardInput = false,
-                CreateNoWindow = true
+                RedirectStandardError = true,
+                UseShellExecute = false
             }
         };
 

--- a/Editor/DownloadFramework.cs
+++ b/Editor/DownloadFramework.cs
@@ -1,4 +1,4 @@
-﻿using UnityEditor;
+using UnityEditor;
 using System.Net;
 using System.IO;
 using System;
@@ -9,15 +9,13 @@ public class DownloadFramework
 {
 
     private readonly string FRAMEWORK_FMT =
-        "https://github.com/fritzlabs/swift-framework/releases/download/{0}/{1}.zip";
+        "https://github.com/fritzlabs/swift-framework/archive/{0}.zip";
     public string version;
-    public string name;
 
 
-    public DownloadFramework(string version, string name)
+    public DownloadFramework(string version)
     {
         this.version = version;
-        this.name = name;
     }
 
     public void Download()
@@ -27,7 +25,7 @@ public class DownloadFramework
             var tempFile = Path.GetTempFileName();
             var tempDir = Path.GetTempPath();
 
-            var path = String.Format(FRAMEWORK_FMT, version, name);
+            var path = String.Format(FRAMEWORK_FMT, version);
 
             client.DownloadFile(new Uri(path), tempFile);
 

--- a/Editor/DownloadFramework.cs
+++ b/Editor/DownloadFramework.cs
@@ -29,6 +29,8 @@ public class DownloadFramework
 
             client.DownloadFile(new Uri(path), tempFile);
 
+            ExecuteBashCommand(String.Format("unzip -q -o {0} -d {1}", tempFile, tempDir));
+            ExecuteBashCommand(String.Format("mkdir -p Assets/Plugins/iOS/Frameworks/"));
             var result = ExecuteBashCommand(
                 String.Format("cp -R {0}/swift-framework-{1}/Frameworks/* {2}", tempDir, version, "Assets/Plugins/iOS/Frameworks/")
             );

--- a/Editor/DownloadFramework.cs
+++ b/Editor/DownloadFramework.cs
@@ -32,7 +32,7 @@ public class DownloadFramework
             ExecuteBashCommand(String.Format("unzip -q -o {0} -d {1}", tempFile, tempDir));
             ExecuteBashCommand(String.Format("mkdir -p Assets/Plugins/iOS/Frameworks/"));
             var result = ExecuteBashCommand(
-                String.Format("cp -R {0}/Frameworks/* {1}", tempDir, "Assets/Plugins/iOS/Frameworks/")
+                String.Format("cp -R {0}/swift-framework-{1}/Frameworks/* {2}", tempDir, version, "Assets/Plugins/iOS/Frameworks/")
             );
             AssetDatabase.Refresh();
         }
@@ -51,8 +51,8 @@ public class DownloadFramework
                 FileName = "/bin/bash",
                 Arguments = "-c \"" + command + "\"",
                 UseShellExecute = false,
-                RedirectStandardOutput = false,
-                RedirectStandardError = false,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
                 RedirectStandardInput = false,
                 CreateNoWindow = true
             }

--- a/Editor/DownloadFramework.cs
+++ b/Editor/DownloadFramework.cs
@@ -32,7 +32,7 @@ public class DownloadFramework
             ExecuteBashCommand(String.Format("unzip -q -o {0} -d {1}", tempFile, tempDir));
             ExecuteBashCommand(String.Format("mkdir -p Assets/Plugins/iOS/Frameworks/"));
             var result = ExecuteBashCommand(
-                String.Format("cp -R {0}/swift-framework-{1}/Frameworks/* {2}", tempDir, version, "Assets/Plugins/iOS/Frameworks/")
+                String.Format("rsync -a {0}/swift-framework-{1}/Frameworks ./Assets/Plugins/iOS/Frameworks --exclude FritzVisionHumanPoseModelSmall.framework --exclude FritzVisionDepthModel.framework", tempDir, version)
             );
             AssetDatabase.Refresh(ImportAssetOptions.ForceSynchronousImport | ImportAssetOptions.ForceUpdate);
 

--- a/Editor/FritzConfiguration.cs
+++ b/Editor/FritzConfiguration.cs
@@ -112,7 +112,7 @@ public class FritzConfiguration : ScriptableObject
         if (settings == null)
         {
             settings = ScriptableObject.CreateInstance<FritzConfiguration>();
-            settings.sdkVersion = "4.1.1";
+            settings.sdkVersion = "5.3.1";
 
             AssetDatabase.CreateAsset(settings, k_FritzConfigurationPath);
             AssetDatabase.SaveAssets();

--- a/Editor/FritzConfiguration.cs
+++ b/Editor/FritzConfiguration.cs
@@ -1,4 +1,4 @@
-﻿using System.IO;
+using System.IO;
 using System.Collections.Generic;
 using UnityEngine;
 using UnityEditor;
@@ -51,9 +51,7 @@ static class FritzConfigurationIMGUIRegister
                 if (GUILayout.Button("Download", GUILayout.Width(mediumButtonSize)))
                 {
                     var sdkVersion = settings.FindProperty("sdkVersion").stringValue;
-                    var download = new DownloadFramework(sdkVersion, "FritzBase");
-                    download.Download();
-                    download = new DownloadFramework(sdkVersion, "FritzVisionPoseModel");
+                    var download = new DownloadFramework(sdkVersion);
                     download.Download();
                 }
 
@@ -99,8 +97,7 @@ public class FritzConfiguration : ScriptableObject
     // Required Frameworks
     public FritzFramework[] frameworks =
     {
-        new FritzFramework("FritzVision"),
-        new FritzFramework("FritzVisionPoseModel")
+        new FritzFramework("Fritz")
     };
 
     internal static FritzConfiguration GetOrCreateSettings()

--- a/Editor/FritzInfoPostProcess.cs
+++ b/Editor/FritzInfoPostProcess.cs
@@ -1,7 +1,9 @@
-﻿using UnityEngine;
+using UnityEngine;
 using UnityEditor;
 using UnityEditor.Callbacks;
+#if UNITY_IOS
 using UnityEditor.iOS.Xcode;
+#endif
 using System.IO;
 
 public static class FritzInfoPostProcess
@@ -11,11 +13,7 @@ public static class FritzInfoPostProcess
     [PostProcessBuild]
     public static void OnPostProcessBuild(BuildTarget buildTarget, string buildPath)
     {
-        if (buildTarget != BuildTarget.iOS)
-        {
-            return;
-        }
-
+        #if UNITY_IOS
         string sourcePath = "Runtime/iOS/Source/";
         string sourceFolder = Path.Combine(PACKAGE_PATH, sourcePath);
         string libraryPath = "Libraries/ai.fritz.vision/Runtime/iOS/Source/";
@@ -48,6 +46,7 @@ public static class FritzInfoPostProcess
         infoPlist.ReadFromFile(infoPath);
         infoPlist.root.SetString("NSCameraUsageDescription", "For ML Camera Usage");
         File.WriteAllText(infoPath, infoPlist.WriteToString());
+        #endif
     }
 
 }

--- a/Editor/SwiftPostProcess.cs
+++ b/Editor/SwiftPostProcess.cs
@@ -1,6 +1,8 @@
-﻿using UnityEditor;
+using UnityEditor;
 using UnityEditor.Callbacks;
+#if UNITY_IOS
 using UnityEditor.iOS.Xcode;
+#endif
 
 public static class SwiftPostProcess
 {
@@ -8,8 +10,7 @@ public static class SwiftPostProcess
     [PostProcessBuild]
     public static void OnPostProcessBuild(BuildTarget buildTarget, string buildPath)
     {
-        if (buildTarget == BuildTarget.iOS)
-        {
+        #if UNITY_IOS
             var projPath = buildPath + "/Unity-Iphone.xcodeproj/project.pbxproj";
             var proj = new PBXProject();
             proj.ReadFromFile(projPath);
@@ -29,7 +30,7 @@ public static class SwiftPostProcess
             proj.AddBuildProperty(targetGuid, "SWIFT_VERSION", "5.0");
             proj.AddBuildProperty(targetGuid, "COREML_CODEGEN_LANGUAGE", "Swift");
             proj.WriteToFile(projPath);
-        }
+        #endif
     }
 
 }

--- a/Editor/SwiftPostProcess.cs
+++ b/Editor/SwiftPostProcess.cs
@@ -30,42 +30,42 @@ public static class SwiftPostProcess
             proj.AddBuildProperty(targetGuid, "SWIFT_VERSION", "5.0");
             proj.AddBuildProperty(targetGuid, "COREML_CODEGEN_LANGUAGE", "Swift");
             proj.AddShellScriptBuildPhase(targetGuid, "Remove x86/x64 binaries from frameworks", "/bin/sh", @"
-                echo "Target architectures: $ARCHS"
+                echo ""Target architectures: $ARCHS""
 
-                APP_PATH="${TARGET_BUILD_DIR}/${WRAPPER_NAME}"
+                APP_PATH=""${TARGET_BUILD_DIR}/${WRAPPER_NAME}""
 
-                find "$APP_PATH" -name '*.framework' -type d | while read -r FRAMEWORK
+                find ""$APP_PATH"" -name '*.framework' -type d | while read -r FRAMEWORK
                 do
-                FRAMEWORK_EXECUTABLE_NAME=$(defaults read "$FRAMEWORK/Info.plist" CFBundleExecutable)
-                FRAMEWORK_EXECUTABLE_PATH="$FRAMEWORK/$FRAMEWORK_EXECUTABLE_NAME"
-                echo "Executable is $FRAMEWORK_EXECUTABLE_PATH"
-                echo $(lipo -info "$FRAMEWORK_EXECUTABLE_PATH")
+                FRAMEWORK_EXECUTABLE_NAME=$(defaults read ""$FRAMEWORK/Info.plist"" CFBundleExecutable)
+                FRAMEWORK_EXECUTABLE_PATH=""$FRAMEWORK/$FRAMEWORK_EXECUTABLE_NAME""
+                echo ""Executable is $FRAMEWORK_EXECUTABLE_PATH""
+                echo $(lipo -info ""$FRAMEWORK_EXECUTABLE_PATH"")
 
-                FRAMEWORK_TMP_PATH="$FRAMEWORK_EXECUTABLE_PATH-tmp"
+                FRAMEWORK_TMP_PATH=""$FRAMEWORK_EXECUTABLE_PATH-tmp""
 
                 # remove simulator's archs if location is not simulator's directory
-                case "${TARGET_BUILD_DIR}" in
-                *"iphonesimulator")
-                    echo "No need to remove archs"
+                case ""${TARGET_BUILD_DIR}"" in
+                *""iphonesimulator"")
+                    echo ""No need to remove archs""
                     ;;
                 *)
-                    if $(lipo "$FRAMEWORK_EXECUTABLE_PATH" -verify_arch "i386") ; then
-                    lipo -output "$FRAMEWORK_TMP_PATH" -remove "i386" "$FRAMEWORK_EXECUTABLE_PATH"
-                    echo "i386 architecture removed"
-                    rm "$FRAMEWORK_EXECUTABLE_PATH"
-                    mv "$FRAMEWORK_TMP_PATH" "$FRAMEWORK_EXECUTABLE_PATH"
+                    if $(lipo ""$FRAMEWORK_EXECUTABLE_PATH"" -verify_arch ""i386"") ; then
+                    lipo -output ""$FRAMEWORK_TMP_PATH"" -remove ""i386"" ""$FRAMEWORK_EXECUTABLE_PATH""
+                    echo ""i386 architecture removed""
+                    rm ""$FRAMEWORK_EXECUTABLE_PATH""
+                    mv ""$FRAMEWORK_TMP_PATH"" ""$FRAMEWORK_EXECUTABLE_PATH""
                     fi
-                    if $(lipo "$FRAMEWORK_EXECUTABLE_PATH" -verify_arch "x86_64") ; then
-                    lipo -output "$FRAMEWORK_TMP_PATH" -remove "x86_64" "$FRAMEWORK_EXECUTABLE_PATH"
-                    echo "x86_64 architecture removed"
-                    rm "$FRAMEWORK_EXECUTABLE_PATH"
-                    mv "$FRAMEWORK_TMP_PATH" "$FRAMEWORK_EXECUTABLE_PATH"
+                    if $(lipo ""$FRAMEWORK_EXECUTABLE_PATH"" -verify_arch ""x86_64"") ; then
+                    lipo -output ""$FRAMEWORK_TMP_PATH"" -remove ""x86_64"" ""$FRAMEWORK_EXECUTABLE_PATH""
+                    echo ""x86_64 architecture removed""
+                    rm ""$FRAMEWORK_EXECUTABLE_PATH""
+                    mv ""$FRAMEWORK_TMP_PATH"" ""$FRAMEWORK_EXECUTABLE_PATH""
                     fi
                     ;;
                 esac
 
-                echo "Completed for executable $FRAMEWORK_EXECUTABLE_PATH"
-                echo $(lipo -info "$FRAMEWORK_EXECUTABLE_PATH")
+                echo ""Completed for executable $FRAMEWORK_EXECUTABLE_PATH""
+                echo $(lipo -info ""$FRAMEWORK_EXECUTABLE_PATH"")
 
                 done
             ");

--- a/Editor/SwiftPostProcess.cs
+++ b/Editor/SwiftPostProcess.cs
@@ -43,7 +43,7 @@ public static class SwiftPostProcess
 
                 FRAMEWORK_TMP_PATH=""$FRAMEWORK_EXECUTABLE_PATH-tmp""
 
-                # remove simulator's archs if location is not simulator's directory
+                : remove simulator's archs if location is not simulator's directory
                 case ""${TARGET_BUILD_DIR}"" in
                 *""iphonesimulator"")
                     echo ""No need to remove archs""

--- a/Editor/SwiftPostProcess.cs
+++ b/Editor/SwiftPostProcess.cs
@@ -29,6 +29,47 @@ public static class SwiftPostProcess
             proj.AddBuildProperty(targetGuid, "DEFINES_MODULE", "YES");
             proj.AddBuildProperty(targetGuid, "SWIFT_VERSION", "5.0");
             proj.AddBuildProperty(targetGuid, "COREML_CODEGEN_LANGUAGE", "Swift");
+            proj.AddShellScriptBuildPhase(targetGuid, "Remove x86/x64 binaries from frameworks", "/bin/sh", @"
+                echo "Target architectures: $ARCHS"
+
+                APP_PATH="${TARGET_BUILD_DIR}/${WRAPPER_NAME}"
+
+                find "$APP_PATH" -name '*.framework' -type d | while read -r FRAMEWORK
+                do
+                FRAMEWORK_EXECUTABLE_NAME=$(defaults read "$FRAMEWORK/Info.plist" CFBundleExecutable)
+                FRAMEWORK_EXECUTABLE_PATH="$FRAMEWORK/$FRAMEWORK_EXECUTABLE_NAME"
+                echo "Executable is $FRAMEWORK_EXECUTABLE_PATH"
+                echo $(lipo -info "$FRAMEWORK_EXECUTABLE_PATH")
+
+                FRAMEWORK_TMP_PATH="$FRAMEWORK_EXECUTABLE_PATH-tmp"
+
+                # remove simulator's archs if location is not simulator's directory
+                case "${TARGET_BUILD_DIR}" in
+                *"iphonesimulator")
+                    echo "No need to remove archs"
+                    ;;
+                *)
+                    if $(lipo "$FRAMEWORK_EXECUTABLE_PATH" -verify_arch "i386") ; then
+                    lipo -output "$FRAMEWORK_TMP_PATH" -remove "i386" "$FRAMEWORK_EXECUTABLE_PATH"
+                    echo "i386 architecture removed"
+                    rm "$FRAMEWORK_EXECUTABLE_PATH"
+                    mv "$FRAMEWORK_TMP_PATH" "$FRAMEWORK_EXECUTABLE_PATH"
+                    fi
+                    if $(lipo "$FRAMEWORK_EXECUTABLE_PATH" -verify_arch "x86_64") ; then
+                    lipo -output "$FRAMEWORK_TMP_PATH" -remove "x86_64" "$FRAMEWORK_EXECUTABLE_PATH"
+                    echo "x86_64 architecture removed"
+                    rm "$FRAMEWORK_EXECUTABLE_PATH"
+                    mv "$FRAMEWORK_TMP_PATH" "$FRAMEWORK_EXECUTABLE_PATH"
+                    fi
+                    ;;
+                esac
+
+                echo "Completed for executable $FRAMEWORK_EXECUTABLE_PATH"
+                echo $(lipo -info "$FRAMEWORK_EXECUTABLE_PATH")
+
+                done
+            ");
+        
             proj.WriteToFile(projPath);
         #endif
     }

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Select `iOS` and click `Switch Platform`. After the process finishes, click on `
 4. In Project Settings, click `Fritz`.
 5. If you have not done so, [Sign up for a free account](https://app.fritz.ai/register?utc_source=github&utc_campaign=fritz-unity-sdk) then create an app on Fritz that matches the Bundle ID defined in unity.
 6. Copy the API Key from the Fritz webapp (`Project Settings > "Your App" > Show API Key`) into the iOS API Key input.
-7. Click download to download the necessary Fritz Frameworks. If you are using Xcode 10.3, set version to 4.0.1.
+7. Click download to download the necessary Fritz Frameworks. If you are using Xcode 11.4, set version to 5.3.1.
 8. In the Unity `Build Settings` window, click `Build and Run`.
 9. Click on Window -> Package Manager. From there, add the ARFoundation and ARKit XR Plugin.
 

--- a/Runtime/README.md
+++ b/Runtime/README.md
@@ -26,7 +26,7 @@ Select `iOS` and click `Switch Platform`. After the process finishes, click on `
 4. In Project Settings, click `Fritz`.
 5. If you have not done so, [Sign up for a free account](https://app.fritz.ai/register) then create an app on Fritz that matches the Bundle ID defined in unity.
 6. Copy the API Key from the Fritz webapp (`Project Settings > "Your App" > Show API Key`) into the iOS API Key input.
-7. Click download to download the necessary Fritz Frameworks. If you are using Xcode 10.3, set version to 4.0.1.
+7. Click download to download the necessary Fritz Frameworks. If you are using Xcode 11.4, set version to 5.3.1.
 8. In the Unity `Build Settings` window, click `Build and Run`.
 9. Click on Window -> Package Manager. From there, add the ARFoundation and ARKit XR Plugin.
 

--- a/Runtime/iOS/README.md
+++ b/Runtime/iOS/README.md
@@ -13,7 +13,7 @@
   ### Download Fritz Frameworks
   Click the Download button to download the Fritz Frameworks.
   
-  Note: If you are using Xcode 10, use version 4.0.1. If you are using Xcode 11 Beta 5, use at least 4.1.0.
+  Note: If you are using Xcode 11.4, set version to 5.3.1.
   
 3. Add ARKit Packages
 

--- a/Runtime/iOS/Source/FritzVisionUnity.swift
+++ b/Runtime/iOS/Source/FritzVisionUnity.swift
@@ -10,7 +10,7 @@ import Foundation
 
 import AVFoundation
 import UIKit
-import FritzVisionPoseModel
+import FritzVisionHumanPoseModelFast
 
 
 
@@ -72,7 +72,7 @@ import FritzVisionPoseModel
 @objc public class FritzVisionUnityPoseModel: NSObject {
 
   var latestPose: FritzVisionPoseResult<HumanSkeleton>?
-  lazy var poseModel = FritzVisionHumanPoseModel()
+  lazy var poseModel = FritzVisionHumanPoseModelFast()
 
   @objc public var callbackTarget = "FritzPoseController"
   @objc public var callbackFunctionTarget = "UpdatePose"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ai.fritz.vision",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "displayName": "Fritz Vision",
   "description": "Integrate mobile ML experiences with Fritz + Unity",
   "unity": "2019.2",


### PR DESCRIPTION
I have updated the iOS parts to allow building on the latest version of Xcode (required for new apps), and that also meant I need to fix it to work with Fritz 5.3+. 

I also had to add a build phase script to remove x86 and x86_64 binaries from the Fritz frameworks as Apple doesn't allow those to be uploaded to the App Store. They only get removed when building for a physical device (so Simulator should still work).